### PR TITLE
Event streaming decouple

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,16 @@ LKSL.Common.Streams.pas
 
 LKSL.Events.Base.pas
 --------------------
+	24th January 2015:
+		- Removed "TLKEventSimple" because it is no longer required.
+		- TLKEvent no longer inherits from TLKStreamable, thus no longer requires overriding of the following:
+			- "RemoveEventFromStream"
+			- "ReadEventFromStream"
+			- "InsertEventIntoStream"
+			- "WriteEventToStream"
+		- The aforementioned methods no longer exist in TLKEvent.
+		- Added "TLKEventStreamable<T: TLKEvent>", which is a "Streamable Descriptor" for an associated TLKEvent Type.
+		- Rewritten the entire Event Recorder, Event Transmitter, and Event Receiver systems to use TLKEventStreamable<T: TLKEvent>
 	7th January 2015:
 		- Added "TLKEventSimple" (A cut-down version of TLKEvent which doesn't support custom data)
 	27th December 2014:

--- a/Source/Delphi/Lib/Events/LKSL.Events.Base.pas
+++ b/Source/Delphi/Lib/Events/LKSL.Events.Base.pas
@@ -146,7 +146,7 @@ type
   protected
     // You MUST override "Clone"
     // (Remembering to type-cast "AFromEvent" to your Event Type) populate your Event Type's properties.
-    procedure Clone(const AFromEvent: TLKEvent); overload; virtual; abstract;
+    procedure Clone(const AFromEvent: TLKEvent); virtual; abstract;
     // Override "GetDefaultAllowRecording" if you want to PREVENT your Event from being recorded for replay.
     // You can also set individual Event Instances to Allow or Disallow recording by setting the
     // "AllowRecording" property to True (will record) or False (won't record)

--- a/Source/Delphi/Lib/Events/LKSL.Events.Base.pas
+++ b/Source/Delphi/Lib/Events/LKSL.Events.Base.pas
@@ -144,26 +144,27 @@ type
     procedure SetExpiresAfter(const AExpiresAfter: LKFloat);
     procedure SetIsReplay(const AIsReplay: Boolean);
   protected
-    // You MUST override "Clone"
-    // (Remembering to type-cast "AFromEvent" to your Event Type) populate your Event Type's properties.
+    ///  <summary><c>Populates the referenced Instance with the values of AFromEvent</c></summary>
+    ///  <param name="AFromEvent"><c>A reference to the source Instance</c></param>
+    ///  <comments><c>MUST be overriden in descendant classes</c></comments>
     procedure Clone(const AFromEvent: TLKEvent); virtual; abstract;
-    // Override "GetDefaultAllowRecording" if you want to PREVENT your Event from being recorded for replay.
-    // You can also set individual Event Instances to Allow or Disallow recording by setting the
-    // "AllowRecording" property to True (will record) or False (won't record)
-    // Default = True
-    // CRITICAL: If your Event Type contains a Pointer or Reference, you must NOT let it be recorded!
+    ///  <summary><c>Defines the default Recording Permission state.</c></summary>
+    ///  <returns><c>True = Allow Recording</c> Default = True</returns>
+    ///  <comments><c>Override if you wish to default to False</c></comments>
+    ///  <remarks><c>Recording can only work if a TLKEventStreamHandler exists to describe an implementing TLKEvent Type</c></remarks>
     function GetDefaultAllowRecording: Boolean; virtual;
-    // Override "GetDefaultExpiresAfter" if you want your Event to Expire after a certain amount of time
-    // (measured in seconds). By default, it returns 0.00 to indiciate that the Event should NEVER expire.
+    ///  <summary><c>Defines the default Expiration Time.</c></summary>
+    ///  <returns><c>Expiration Time in Seconds (Default = 0.00)</c></returns>
+    ///  <comments><c>Override if you want the Event Type to expire after a period of time by default.</c></comments>
     function GetDefaultExpiresAfter: LKFloat; virtual;
-    // Override "GetDefaultAllowTransmit" if you want the Event to be passed over to your Event Streaming
-    // system. Your Event Transmission system should then decide where this Event should be Streamed to.
-    // By default, it returns "False" indicating that this Event isn't intended to be Streamed to
-    // another process.
+    ///  <summary><c>Defines the default Transmit Permission state.</c></summary>
+    ///  <returns><c>True = Allow Transmit</c> Default = False</returns>
+    ///  <comments><c>Override if you wish to default to True</c></comments>
+    ///  <remarks><c>Transmission can only work if a TLKEventStreamHandler exists to describe an implementing TLKEvent Type</c></remarks>    ///
     function GetDefaultAllowTransmit: Boolean; virtual;
-    // Override "GetDispatchModes" if you want the Event to restrict the way your Event Type is dispatched.
-    // Available mode switches are: edmQueue, edmStack, edmThreads.
-    // Default = [edmQueue, edmStack, edmThreads]
+    ///  <summary><c>Defines the default allowable Dispatch Modes for the Event.</c></summary>
+    ///  <returns><c>A Set containing one or more of: edmQueue, edmStack, edmThreads</c> Default = [edmQueue, edmStack, edmThreads]</returns>
+    ///  <comments><c></c></comments>
     function GetDispatchModes: TLKEventDispatchModes; virtual;
   public
     constructor Create; override;

--- a/Source/Delphi/Lib/Streams/LKSL.Streamables.Base.pas
+++ b/Source/Delphi/Lib/Streams/LKSL.Streamables.Base.pas
@@ -118,10 +118,10 @@ type
     // Creates a BLANK instance of your Streamable
     constructor Create; override;
     // Creates a POPULATED instance of your Streamable from a Stream
-    constructor CreateFromStream(const AStream: TStream); overload;
+    constructor CreateFromStream(const AStream: TStream); overload; virtual;
     constructor CreateFromStream(const AStream: TStream; const APosition: Int64); overload;
     // Creates a POPULATED instance of your Streamable from a File
-    constructor CreateFromFile(const AFileName: String);
+    constructor CreateFromFile(const AFileName: String); virtual;
     // "GetBlockSize" returns the Block Size for a given Streamable from within a given Stream.
     // It does this without
     // You MUST provide a UNIQUE GUID String identifier for ALL Streamable Types
@@ -229,6 +229,8 @@ type
   end;
 
 var
+  /// <summary><c>Global Streamable Types Manager</c></summary>
+  /// <description><c>For Registering Streamable Types, and retreiving the correct Streamable Type from a given Stream or GUID.</c></description>
   Streamables: TLKStreamables;
 
 implementation


### PR DESCRIPTION
TLKEvent is no longer a TLKStreamable object, thus there's far less to override and implement for basic Event types.

If you want to be able to Record or Transmit an Event, you'll need to create a companion type of TLKEvent from TLKEventStreamable.

I suggest using:

```Delphi
TMyEventTypeStreamable = TLKEventStreamable<TMyEventType>
```

This reduces further the amount of overrides to implement!

Here is a really simple example of defining a TLKEvent class:

```Delphi
type
  TTestEvent = class(TLKEvent)
  private
    FString: String;
  protected
    procedure Clone(const AFromEvent: TLKEvent); override;
  public
    constructor Create(const AString: String); reintroduce;
    property SomeString: String read FString;
  end;
```

And here's the implementation for it:

```Delphi
{ TTestEvent }

procedure TTestEvent.Clone(const AFromEvent: TLKEvent);
begin
  FString := TTestEvent(AFromEvent).FString;
end;

constructor TTestEvent.Create(const AString: String);
begin
  inherited Create;
  FString := AString;
end;
```

Easy, right?

Now, let's provide a Streamable Handler for it...

```Delphi
  TTestEventStreamable = class(TLKEventStreamable<TTestEvent>)
  protected
    procedure ReadEventFromStream(const AEvent: TTestEvent; const AStream: TStream); overload; override;
    procedure InsertEventIntoStream(const AEvent: TTestEvent; const AStream: TStream); overload; override;
    procedure WriteEventToStream(const AEvent: TTestEvent; const AStream: TStream); overload; override;
  public
    class function GetTypeGUID: TGUID; override;
  end;
```

And its implementation:

```Delphi

{ TTestEventStreamable }

class function TTestEventStreamable.GetTypeGUID: TGUID;
const
  TYPE_GUID: TGUID = '{2269CA30-923A-4167-9013-7E9EFB89E667}';
begin
  Result := TYPE_GUID;
end;

procedure TTestEventStreamable.InsertEventIntoStream(const AEvent: TTestEvent; const AStream: TStream);
begin
  inherited;
  StreamInsertString(AStream, AEvent.FString);
end;

procedure TTestEventStreamable.ReadEventFromStream(const AEvent: TTestEvent; const AStream: TStream);
begin
  inherited;
  AEvent.FString := StreamReadString(AStream);
end;

procedure TTestEventStreamable.WriteEventToStream(const AEvent: TTestEvent; const AStream: TStream);
begin
  inherited;
  StreamWriteString(AStream, AEvent.FString);
end;

initialization
  TTestEventStreamable.Register;
finalization
  TTestEventStreamable.Unregister;
```

Now we can Record (implemented and functional) or Transmit (temporarily removed for redesign and reimplementation) TTestEvent!